### PR TITLE
docs: fix github links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/inexorabletash/text-encoding.git"
+    "url": "https://github.com/sinonjs/text-encoding.git"
   },
   "keywords": [
     "encoding",
@@ -30,8 +30,8 @@
     "living standard"
   ],
   "bugs": {
-    "url": "https://github.com/inexorabletash/text-encoding/issues"
+    "url": "https://github.com/sinonjs/text-encoding/issues"
   },
-  "homepage": "https://github.com/inexorabletash/text-encoding",
+  "homepage": "https://github.com/sinonjs/text-encoding",
   "license": "(Unlicense OR Apache-2.0)"
 }


### PR DESCRIPTION
The repository links in package.json still point to the upstream unmaintained package.
A new version probably needs to be published to have this change reflected on npmjs too.